### PR TITLE
Remain on current node if subgraph query is not found

### DIFF
--- a/ActionGraph/Prebuilts.fs
+++ b/ActionGraph/Prebuilts.fs
@@ -58,7 +58,10 @@
                         function(fromNode : Node, _, velocity, _) ->
                                 match GraphConversions.collapseGraphLikeToGraph(fromNode.Value) with
                                     | Some a -> 
-                                        a.WalkEdge(velocity, StringValue("queryText"))
+                                        if a.Nodes.ContainsKey(velocity) then
+                                            a.WalkEdge(velocity, StringValue("queryText"))
+                                        else
+                                            fromNode
                                     | None -> fromNode
                     )
                 );


### PR DESCRIPTION
It would be better to show some sort of error message when the subgraph query value is not found, but silently remaining on the current node is probably better than crashing with a `KeyNotFoundException`.

Using the TextAdventureSample as an example
Before:
```
A challenger approaches! Do you attack them (fight), or do you flee (flee)
neither
Unhandled exception. System.Collections.Generic.KeyNotFoundException: The given key was not present in the dictionary.
...
```

After:
```
A challenger approaches! Do you attack them (fight), or do you flee (flee)
neither
flee
You flee! Thanks for playing! (press enter to restart)
```
