### PR TITLE
Add PullRequest GitHubAction

### DIFF
--- a/.github/workflows/pullRequest.yml
+++ b/.github/workflows/pullRequest.yml
@@ -1,0 +1,19 @@
+name: PullRequest
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.x
+    - name: Build - Debug
+      run: dotnet build $GITHUB_WORKSPACE/ActionGraph.sln --configuration Debug
+    - name: Build - Release
+      run: dotnet build $GITHUB_WORKSPACE/ActionGraph.sln --configuration Release


### PR DESCRIPTION
This adds a PR build pipeline will build `ActionGraph.sln` in
Debug/Release. This will make sure any changes to the project from a PR does not break the build. 

Note: With GitHub Free, you get 2000 minutes per month. https://docs.github.com/en/github/setting-up-and-managing-billing-and-payments-on-github/about-billing-for-github-actions
The current build time is less than a minute, so don't have more than 2000 PR's per month.

Example: https://github.com/WardenGnaw/action-graphs/pull/1/checks?check_run_id=1799630826